### PR TITLE
Fix pre detection

### DIFF
--- a/cmd/godocserve/assets/style.css
+++ b/cmd/godocserve/assets/style.css
@@ -828,3 +828,7 @@ a.error {
     white-space: pre-wrap;
   }
 }
+
+blockquote {
+    font-style: italic;
+}

--- a/cmd/godocserve/repos
+++ b/cmd/godocserve/repos
@@ -2,5 +2,4 @@ https://github.com/miekg/dns master
 https://github.com/miekg/pkcs11 master
 https://github.com/gomarkdown/markdown master
 https://github.com/mmarkdown/mmark master
-https://github.com/miekg/exdns master
-https://github.com/miekg/unbound master
+https://github.com/miekg/test main

--- a/comment.go
+++ b/comment.go
@@ -82,6 +82,17 @@ func indentLen(s string) int {
 	return i
 }
 
+func isPre(s string) int {
+	i := 0
+	for i < len(s) && (s[i] == ' ' || s[i] == '\t') {
+		if s[i] == '\t' {
+			i += 3
+		}
+		i++
+	}
+	return i
+}
+
 func isBlank(s string) bool {
 	return len(s) == 0 || (len(s) == 1 && s[0] == '\n')
 }
@@ -274,7 +285,7 @@ func blocks(text string) []block {
 			lastWasBlank = true
 			continue
 		}
-		if indentLen(line) > 0 {
+		if isPre(line) > 3 {
 			// close paragraph
 			close()
 


### PR DESCRIPTION
A package doc starting with "/* Package ..." was seen as a pre-element
which it isn't. Improve the detection of it, so only 3 or more spaces or
a tab signal a pre.

Signed-off-by: Miek Gieben <miek@miek.nl>
